### PR TITLE
[ECA-606] Salvando ordem cancelada independente se houve tentativa de pagamento ou não

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -788,8 +788,8 @@ class Data extends AbstractHelper
             $creditMemo->setInvoice($invoiceObj);
             $this->creditmemoService->refund($creditMemo);
 
+            $order->save();
         }
-        $order->save();
     }
 
     /**

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -787,7 +787,6 @@ class Data extends AbstractHelper
 
             $creditMemo->setInvoice($invoiceObj);
             $this->creditmemoService->refund($creditMemo);
-
         }
 
         $order->save();

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -788,8 +788,9 @@ class Data extends AbstractHelper
             $creditMemo->setInvoice($invoiceObj);
             $this->creditmemoService->refund($creditMemo);
 
-            $order->save();
         }
+
+        $order->save();
     }
 
     /**


### PR DESCRIPTION
Um sller que usa magento reclamou que o pedido não está expirando na plataforma após o callback. Foi notado que o callback era recebido, mas só alterava o valor na database se houvesse alguma tentativa de pagamento. 

Foi acertado essa condição ao colocar o salvamento da ordem fora do `if` condicional do pagamento.

Esse PR também é necessário para testar o projeto [magento2-tests](https://github.com/PicPay/picpay-magento2-tests).